### PR TITLE
Bumping the versions of dependencies used

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -154,6 +154,14 @@
             <artifactId>kafka-oauth-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -90,6 +90,10 @@
             <groupId>com.dajudge.kindcontainer</groupId>
             <artifactId>kindcontainer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
         <!-- JUnit dependency is needed at compile time because MockKube is instantiating the KindContainer in regular scope -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <quartz.version>2.3.2</quartz.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <netty.version>4.1.118.Final</netty.version>
@@ -154,6 +154,8 @@
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>
+        <json-smart.version>2.5.2</json-smart.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
 
         <!-- Test only dependencies -->
         <hamcrest.version>2.2</hamcrest.version>
@@ -664,6 +666,11 @@
                 <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-utils-streams</artifactId>
                 <version>${registry.version}</version>
@@ -821,6 +828,11 @@
                 <groupId>com.dajudge.kindcontainer</groupId>
                 <artifactId>kindcontainer</artifactId>
                 <version>${kindcontainer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
             </dependency>
             <!-- JUnit dependency is needed at compile time by MockKube because of how Test Containers are designed -->
             <dependency>


### PR DESCRIPTION
Bumping the following dependencies

- jetty-server
- json-smart
- commons-compress 